### PR TITLE
Fix compile error

### DIFF
--- a/dmenu.c
+++ b/dmenu.c
@@ -671,7 +671,7 @@ setup(void)
 		/* no focused window is on screen, so use pointer location instead */
 		if (mon < 0 && !area && XQueryPointer(dpy, root, &dw, &dw, &x, &y, &di, &di, &du))
 			for (i = 0; i < n; i++)
-				if (INTERSECT(x, y, 1, 1, info[i]))
+				if (INTERSECT(x, y, 1, 1, info[i]) != 0)
 					break;
 
 		x = info[i].x_org;


### PR DESCRIPTION
dmenu.c:24:30: warning: ‘*’ in boolean context, suggest ‘&&’ instead [-Wint-in-bool-context]